### PR TITLE
feat: RPG-127 add `defeat-opponent` condition

### DIFF
--- a/configurations/demo-config-1/locations/location-1/location-1.json
+++ b/configurations/demo-config-1/locations/location-1/location-1.json
@@ -44,7 +44,7 @@
     { "tag": "tp-bunny", "position": { "row": 7, "col": 8 }, "assetPath": "assets/bunny.png" },
     { "tag": "key", "position": { "row": 6, "col": 3 }, "assetPath": "assets/key.png" },
     { "tag": "bandit", "position": { "row": 2, "col": 0 }, "assetPath": "assets/zombie.png" },
-    { "tag": "object-4", "position": { "row": 3, "col": 7 }, "assetPath": "assets/zombie.png" },
+    { "tag": "zombie", "position": { "row": 3, "col": 7 }, "assetPath": "assets/zombie.png" },
     { "tag": "object-5", "position": { "row": 9, "col": 8 }, "assetPath": "assets/chest.png" },
     { "tag": "object-6", "position": { "row": 9, "col": 9 }, "assetPath": "assets/bush.png" }
   ],

--- a/configurations/demo-config-1/locations/location-1/objects/zombie.json
+++ b/configurations/demo-config-1/locations/location-1/objects/zombie.json
@@ -1,5 +1,5 @@
 {
-  "tag": "object-4",
+  "tag": "zombie",
   "assetPath": "assets/zombie.png",
   "onLeftClick": {
     "tag": "dialogue-action",
@@ -15,6 +15,16 @@
       }
 
     ],
-    "reward": 5
+    "reward": 5,
+    "condition": {
+      "type": "defeat-opponent",
+      "opponent-tag": "bandit"
+    }
+  },
+  "onRightClick": {
+    "tag": "description",
+    "type": "show-description",
+    "assetPath": "assets/zombie.png",
+    "description": "To unlock the quiz you need to defeat the bandit!"
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,6 +224,12 @@ Condition consists of following properties:
 * `type` - One of types:
   * `item-required` - Requires following props:
     * `item-tag` - Tag of the item that must be in the player inventory for the action to be executed.
+        Aliases: `tag`, `itemTag`.
+  * `defeat-opponent` - Requires following props:
+    * `opponent-tag` - Tag of the opponent that must be defeated to unlock the action. Note that as for now, the engine
+        does not check whether specified object exists or has battle action set. For now you must guarantee
+        the correctness. Aliases: `tag`, `opponentTag`.
+        
 
 ## Example of full configuration structure
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,8 +8,9 @@
 4. [Location configuration](#location-configuration)
 5. [`GameObject` configuration](#gameobject-configuration)
 6. [Action configuration](#action-configuration)
-7. [Example of full configuration structure](#example-of-full-configuration-structure)
-8. [Example configurations](#example-configurations)
+7. [Condition configuration](#condition-configuration)
+8. [Example of full configuration structure](#example-of-full-configuration-structure)
+9. [Example configurations](#example-configurations)
 
 ## Root directory
 
@@ -177,7 +178,9 @@ common part first. Each action consists of following properties
 
 * `tag` - Action tag; this is required however it is not used for now. Action tag does not have to be unique for now.
 * `type` - One of action types mentioned above.
-* *(optional)* `before` - Configuration of action to be triggered before the proper action is executed,
+* *(optional)* `condition` - Condition configuration. The action won't be executed until the condition is satisfied.
+    Aliases: `requires`. See [condition configuration](#condition-configuration)
+* *(optional)* `before` - Configuration of action to be triggered before the proper action is executed.
   e.g. you may want to change location before starting the dialogue. (TODO: Logic is not implemented as for now).
 * *(optional)* `after` - Configuration of action to be triggered after the proper action is executed, e.g. you may want
     give player some output or item. (TODO: Logic is not implemented as for now).
@@ -212,6 +215,15 @@ Let's look at specific action types:
   * `assetPath` - Path to the image with background for the dialogue window. As any path, it must be eiter absolute or relative to the engine's source root.
     Aliases: `asset-path`, `asset`.
 
+## Condition configuration
+
+Describes condition that must be satisfied before the action can be executed.
+
+Condition consists of following properties:
+
+* `type` - One of types:
+  * `item-required` - Requires following props:
+    * `item-tag` - Tag of the item that must be in the player inventory for the action to be executed.
 
 ## Example of full configuration structure
 

--- a/src/main/java/io/rpg/config/model/ConditionConfigBundle.java
+++ b/src/main/java/io/rpg/config/model/ConditionConfigBundle.java
@@ -12,7 +12,7 @@ public class ConditionConfigBundle implements ConfigWithValidation {
   private ConditionType type;
 
   @Nullable
-  @SerializedName(value = "item-tag", alternate = {"itemTag", "opponent-tag", "tag"})
+  @SerializedName(value = "item-tag", alternate = {"itemTag", "opponent-tag", "tag", "opponentTag"})
   private String objectTag;
 
   @Nullable

--- a/src/main/java/io/rpg/config/model/ConditionConfigBundle.java
+++ b/src/main/java/io/rpg/config/model/ConditionConfigBundle.java
@@ -12,7 +12,7 @@ public class ConditionConfigBundle implements ConfigWithValidation {
   private ConditionType type;
 
   @Nullable
-  @SerializedName(value = "item-tag", alternate = {"itemTag"})
+  @SerializedName(value = "item-tag", alternate = {"itemTag", "opponent-tag", "tag"})
   private String objectTag;
 
   @Nullable

--- a/src/main/java/io/rpg/config/model/ConditionConfigBundle.java
+++ b/src/main/java/io/rpg/config/model/ConditionConfigBundle.java
@@ -35,6 +35,11 @@ public class ConditionConfigBundle implements ConfigWithValidation {
     return builder.isEmpty() ? Result.ok() : Result.err(new Exception(builder.toString()));
   }
 
+  Result<Void, Exception> validateDefeatOpponent() {
+    // We need to check the same conditions
+    return validateItemRequired();
+  }
+
   @Override
   public Result<Void, Exception> validate() {
     ErrorMessageBuilder builder = new ErrorMessageBuilder();
@@ -49,6 +54,7 @@ public class ConditionConfigBundle implements ConfigWithValidation {
 
     switch (type) {
       case ITEM_REQUIRED -> { return validateItemRequired(); }
+      case DEFEAT_OPPONENT -> { return validateDefeatOpponent(); }
       default -> throw new IllegalArgumentException("Not implemented condition type!");
     }
   }

--- a/src/main/java/io/rpg/config/model/ConditionConfigBundle.java
+++ b/src/main/java/io/rpg/config/model/ConditionConfigBundle.java
@@ -13,7 +13,7 @@ public class ConditionConfigBundle implements ConfigWithValidation {
 
   @Nullable
   @SerializedName(value = "item-tag", alternate = {"itemTag"})
-  private String itemTag;
+  private String objectTag;
 
   @Nullable
   public ConditionType getType() {
@@ -21,14 +21,14 @@ public class ConditionConfigBundle implements ConfigWithValidation {
   }
 
   @Nullable
-  public String getItemTag() {
-    return itemTag;
+  public String getObjectTag() {
+    return objectTag;
   }
 
   Result<Void, Exception> validateItemRequired() {
     ErrorMessageBuilder builder = new ErrorMessageBuilder();
 
-    if (itemTag == null || itemTag.isBlank()) {
+    if (objectTag == null || objectTag.isBlank()) {
       builder.append("No or invalid item tag provided");
     }
 

--- a/src/main/java/io/rpg/controller/Controller.java
+++ b/src/main/java/io/rpg/controller/Controller.java
@@ -184,6 +184,7 @@ public class Controller implements KeyboardEvent.Observer, MouseClickedEvent.Obs
       BattleResult result;
       if (player.getPoints() > opponent.getStrength()) {
         player.addPoints(reward);
+        player.addDefeatedOpponent(opponent.getTag());
         result = new BattleResult(BattleResult.Result.VICTORY, reward);
       } else if (player.getStrength() < opponent.getStrength()) {
         result = new BattleResult(BattleResult.Result.DEFEAT, 0);

--- a/src/main/java/io/rpg/model/actions/ConditionType.java
+++ b/src/main/java/io/rpg/model/actions/ConditionType.java
@@ -4,5 +4,8 @@ import com.google.gson.annotations.SerializedName;
 
 public enum ConditionType {
   @SerializedName("item-required")
-  ITEM_REQUIRED
+  ITEM_REQUIRED,
+
+  @SerializedName("defeat-opponent")
+  DEFEAT_OPPONENT,
 }

--- a/src/main/java/io/rpg/model/actions/condition/ConditionEngine.java
+++ b/src/main/java/io/rpg/model/actions/condition/ConditionEngine.java
@@ -5,13 +5,13 @@ import io.rpg.controller.Controller;
 import java.lang.ref.WeakReference;
 
 public class ConditionEngine {
-  private final WeakReference<Controller> weakRefControler;
+  private final WeakReference<Controller> weakRefController;
 
   public ConditionEngine(final Controller controller) {
-    this.weakRefControler = new WeakReference<>(controller);
+    this.weakRefController = new WeakReference<>(controller);
   }
 
-  public boolean evaluateItemRequiredCondition(ItemRequiredCondition itemRequiredCondition) {
+  public boolean evaluateItemRequiredCondition(ItemRequiredCondition condition) {
     // TODO: Implement this when the inventory gets implemented.
     // Scheme:
 //    return weakRefControler
@@ -20,7 +20,16 @@ public class ConditionEngine {
 //        .getPlayer()
 //        .getInventory()
 //        .getItems()
-//        .containsItemForTag(itemRequiredCondition.getItemTag());
+//        .containsItemForTag(condition.getItemTag());
     return true;
+  }
+
+  public boolean evaluateDefeatOpponentCondition(DefeatOpponentCondition condition) {
+    return weakRefController
+        .get()
+        .getPlayerController()
+        .getPlayer()
+        .getDefeatedOpponents()
+        .contains(condition.getOpponentTag());
   }
 }

--- a/src/main/java/io/rpg/model/actions/condition/ConditionFactory.java
+++ b/src/main/java/io/rpg/model/actions/condition/ConditionFactory.java
@@ -14,6 +14,7 @@ public class ConditionFactory {
     //noinspection ConstantConditions
     switch (config.getType()) {
       case ITEM_REQUIRED -> { return itemRequiredFromConfig(config); }
+      case DEFEAT_OPPONENT -> { return defeatOpponentFromConfig(config); }
       default -> throw new IllegalArgumentException("Not implemented condition type: " + config.getType().toString());
     }
   }
@@ -21,5 +22,10 @@ public class ConditionFactory {
   private static ItemRequiredCondition itemRequiredFromConfig(ConditionConfigBundle config) {
     assert config.getObjectTag() != null;
     return new ItemRequiredCondition(config.getObjectTag());
+  }
+
+  private static DefeatOpponentCondition defeatOpponentFromConfig(ConditionConfigBundle config) {
+    assert config.getObjectTag() != null;
+    return new DefeatOpponentCondition(config.getObjectTag());
   }
 }

--- a/src/main/java/io/rpg/model/actions/condition/ConditionFactory.java
+++ b/src/main/java/io/rpg/model/actions/condition/ConditionFactory.java
@@ -19,7 +19,7 @@ public class ConditionFactory {
   }
 
   private static ItemRequiredCondition itemRequiredFromConfig(ConditionConfigBundle config) {
-    assert config.getItemTag() != null;
-    return new ItemRequiredCondition(config.getItemTag());
+    assert config.getObjectTag() != null;
+    return new ItemRequiredCondition(config.getObjectTag());
   }
 }

--- a/src/main/java/io/rpg/model/actions/condition/DefeatOpponentCondition.java
+++ b/src/main/java/io/rpg/model/actions/condition/DefeatOpponentCondition.java
@@ -1,0 +1,25 @@
+package io.rpg.model.actions.condition;
+
+import io.rpg.model.actions.ConditionType;
+import org.jetbrains.annotations.NotNull;
+
+public class DefeatOpponentCondition extends Condition {
+
+  @NotNull
+  private final String opponentTag;
+
+  public DefeatOpponentCondition(@NotNull final String tag) {
+    super(ConditionType.DEFEAT_OPPONENT);
+    this.opponentTag = tag;
+  }
+
+  @Override
+  public boolean acceptEngine(ConditionEngine engine) {
+    return engine.evaluateDefeatOpponentCondition(this);
+  }
+
+  @NotNull
+  public String getOpponentTag() {
+    return opponentTag;
+  }
+}

--- a/src/main/java/io/rpg/model/object/Player.java
+++ b/src/main/java/io/rpg/model/object/Player.java
@@ -5,6 +5,7 @@ import io.rpg.view.GameObjectView;
 import javafx.geometry.Point2D;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -104,5 +105,9 @@ public class Player extends GameObject {
 
   public void addDefeatedOpponent(@NotNull String tag) {
     this.defeatedOpponents.add(tag);
+  }
+
+  public Set<String> getDefeatedOpponents() {
+    return Collections.unmodifiableSet(defeatedOpponents);
   }
 }

--- a/src/main/java/io/rpg/model/object/Player.java
+++ b/src/main/java/io/rpg/model/object/Player.java
@@ -5,6 +5,10 @@ import io.rpg.view.GameObjectView;
 import javafx.geometry.Point2D;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 public class Player extends GameObject {
 
   private int strength;
@@ -16,6 +20,8 @@ public class Player extends GameObject {
   private GameObjectView gameObjectView;
   private int points;
 
+  private final Set<String> defeatedOpponents;
+
 
   public Player(@NotNull String tag, @NotNull Position position, @NotNull String assetPath) {
     super(tag, position);
@@ -25,6 +31,7 @@ public class Player extends GameObject {
     this.upPressed = false;
     this.downPressed = false;
     this.strength = 0;
+    this.defeatedOpponents = new LinkedHashSet<>();
   }
 
   public void updateStrength(int value) {
@@ -93,5 +100,9 @@ public class Player extends GameObject {
 
   public int getStrength() {
     return strength;
+  }
+
+  public void addDefeatedOpponent(@NotNull String tag) {
+    this.defeatedOpponents.add(tag);
   }
 }


### PR DESCRIPTION
# Description

Added `defeat-opponent` condition. It allows for the action to be executed only if opponent specified in configuration has been defeated by the player.

Should be merged after:

* #73

# Test case

I updated the configuration so you can see it works:

1. Go to zombie in first location. Try interact with him & see that the quiz action does not trigger. See his description (you need to defeat a bandit).
2. Go to second location to gain some points (otherwise you can not defeat the bandit).
3. Defeat the bandit.
4. Go back to the zombie and take the quiz!

# Checklist

* [x] Included code to test these changes
* [x] Updated Jira
