### PR TITLE
refact: remove reflection in favor of visitor pattern

### DIFF
--- a/src/main/java/io/rpg/model/actions/Action.java
+++ b/src/main/java/io/rpg/model/actions/Action.java
@@ -4,5 +4,12 @@ package io.rpg.model.actions;
  * A marker interface for action classes.
  */
 public interface Action {
-  Action VOID = new Action() {};
+  Action VOID = new Action() {
+    @Override
+    public void acceptActionEngine(ActionEngine engine) {
+      /* noop */
+    }
+  };
+
+  void acceptActionEngine(final ActionEngine engine);
 }

--- a/src/main/java/io/rpg/model/actions/ActionEngine.java
+++ b/src/main/java/io/rpg/model/actions/ActionEngine.java
@@ -1,0 +1,129 @@
+package io.rpg.model.actions;
+
+import io.rpg.controller.Controller;
+import io.rpg.model.location.LocationModel;
+import io.rpg.model.object.GameObject;
+import io.rpg.model.object.Player;
+import io.rpg.util.BattleResult;
+import io.rpg.view.LocationView;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.ref.WeakReference;
+
+public final class ActionEngine {
+
+  private final WeakReference<Controller> weakRefController;
+
+  private final Logger logger = LogManager.getLogger(ActionEngine.class);
+
+  public ActionEngine(final Controller controller) {
+    weakRefController = new WeakReference<>(controller);
+  }
+
+  @NotNull
+  private Controller controller() throws IllegalStateException {
+    Controller controller = weakRefController.get();
+    if (controller == null) throw new IllegalStateException("Controller was dropped but ActionEngine still executes");
+    return controller;
+  }
+
+  public void onAction(LocationChangeAction action) {
+    actionGuard(action, () -> {
+      if (!controller().getTagToLocationModelMap().containsKey(action.destinationLocationTag)) {
+        logger.error("Unknown location tag");
+        return;
+      }
+
+      LocationView nextView = controller().getTagToLocationViewMap().get(action.destinationLocationTag);
+      LocationModel nextModel = controller().getTagToLocationModelMap().get(action.destinationLocationTag);
+
+      controller().getPlayerController().teleportTo(nextModel, nextView, action.playerPosition);
+
+      controller().setCurrentModel(nextModel);
+      controller().setView(nextView);
+      controller().getMainStage().setScene(nextView);
+    });
+  }
+
+  public void onAction(DialogueAction action) {
+    actionGuard(action, () -> {
+      var controller = controller();
+      controller.getPopupController().openDialoguePopup(action.text, action.image,
+          controller.getWindowCenterX(), controller.getWindowCenterY());
+    });
+  }
+
+  public void onAction(ShowDescriptionAction action) {
+    actionGuard(action, () -> {
+      if (!action.description.isEmpty()) {
+        var controller = controller();
+        controller.getPopupController().openTextImagePopup(action.description, action.image,
+            controller.getWindowCenterX(), controller.getWindowCenterY());
+      }
+    });
+  }
+
+  public void onAction(QuizAction action) {
+    actionGuard(action, () -> {
+      var controller = controller();
+      int pointsCount = action.getPointsToEarn();
+      controller.getPopupController().openQuestionPopup(
+          action.question,
+          controller.getWindowCenterX(), controller.getWindowCenterY(),
+          () -> acceptQuizResult(true, pointsCount),
+          () -> acceptQuizResult(false, 0)
+      );
+      action.setPointsToEarn(0);
+    });
+  }
+
+  public void acceptQuizResult(boolean correct, int pointsCount) {
+    var controller = controller();
+    if (correct) {
+      controller.getPlayerController().addPoints(pointsCount);
+      controller.getPopupController().hidePopup();
+      if (pointsCount > 0)
+        controller.getPopupController().openPointsPopup(pointsCount, controller.getWindowCenterX(), controller.getWindowCenterY());
+    } else {
+      controller.getPopupController().hidePopup();
+      System.out.println("wrong answer");
+    }
+  }
+
+  public void onAction(GameEndAction action) {
+    actionGuard(action, () -> {
+      var controller = controller();
+      controller.getGameEndController().showGameEnd(controller.getMainStage(), action.description);
+    });
+  }
+
+  public void onAction(BattleAction action) {
+    actionGuard(action, () -> {
+      Player player = controller().getPlayerController().getPlayer();
+      GameObject opponent = action.getOpponent();
+      int reward = action.getReward();
+      BattleResult result;
+      if (player.getPoints() > opponent.getStrength()) {
+        player.addPoints(reward);
+        player.addDefeatedOpponent(opponent.getTag());
+        result = new BattleResult(BattleResult.Result.VICTORY, reward);
+      } else if (player.getStrength() < opponent.getStrength()) {
+        result = new BattleResult(BattleResult.Result.DEFEAT, 0);
+      } else {
+        result = new BattleResult(BattleResult.Result.DRAW, 0);
+      }
+      controller().getPopupController().openTextPopup(result.getMessage(),
+          controller().getWindowCenterX(), controller().getWindowCenterY());
+    });
+  }
+
+  private void actionGuard(ConditionalAction action, Runnable actionLogic) {
+    if (action.getCondition() != null && !action.getCondition().acceptEngine(controller().getConditionEngine())) {
+      logger.info("Action not executed due to condition being not satisfied");
+      return;
+    }
+    actionLogic.run();
+  }
+}

--- a/src/main/java/io/rpg/model/actions/ActionEngine.java
+++ b/src/main/java/io/rpg/model/actions/ActionEngine.java
@@ -88,7 +88,7 @@ public final class ActionEngine {
         controller.getPopupController().openPointsPopup(pointsCount, controller.getWindowCenterX(), controller.getWindowCenterY());
     } else {
       controller.getPopupController().hidePopup();
-      System.out.println("wrong answer");
+      logger.info("Wrong answer provided");
     }
   }
 

--- a/src/main/java/io/rpg/model/actions/BattleAction.java
+++ b/src/main/java/io/rpg/model/actions/BattleAction.java
@@ -3,7 +3,7 @@ package io.rpg.model.actions;
 import io.rpg.model.actions.condition.Condition;
 import io.rpg.model.object.GameObject;
 
-public class BattleAction extends ConditionalAction {
+public final class BattleAction extends ConditionalAction {
   private GameObject opponent;
   private final int reward;
 
@@ -22,5 +22,10 @@ public class BattleAction extends ConditionalAction {
 
   public int getReward() {
     return reward;
+  }
+
+  @Override
+  public void acceptActionEngine(ActionEngine engine) {
+    engine.onAction(this);
   }
 }

--- a/src/main/java/io/rpg/model/actions/DialogueAction.java
+++ b/src/main/java/io/rpg/model/actions/DialogueAction.java
@@ -15,4 +15,9 @@ public class DialogueAction extends ConditionalAction {
     this.text = text;
     this.image = image;
   }
+
+  @Override
+  public void acceptActionEngine(ActionEngine engine) {
+    engine.onAction(this);
+  }
 }

--- a/src/main/java/io/rpg/model/actions/GameEndAction.java
+++ b/src/main/java/io/rpg/model/actions/GameEndAction.java
@@ -9,4 +9,9 @@ public class GameEndAction extends ConditionalAction {
     super(condition);
     this.description = description;
   }
+
+  @Override
+  public void acceptActionEngine(ActionEngine engine) {
+    engine.onAction(this);
+  }
 }

--- a/src/main/java/io/rpg/model/actions/LocationChangeAction.java
+++ b/src/main/java/io/rpg/model/actions/LocationChangeAction.java
@@ -23,4 +23,9 @@ public class LocationChangeAction extends ConditionalAction {
     this.destinationLocationTag = destinationLocationTag;
     this.playerPosition = playerPosition;
   }
+
+  @Override
+  public void acceptActionEngine(ActionEngine engine) {
+    engine.onAction(this);
+  }
 }

--- a/src/main/java/io/rpg/model/actions/QuizAction.java
+++ b/src/main/java/io/rpg/model/actions/QuizAction.java
@@ -26,4 +26,8 @@ public class QuizAction extends ConditionalAction {
     return pointsToEarn;
   }
 
+  @Override
+  public void acceptActionEngine(ActionEngine engine) {
+    engine.onAction(this);
+  }
 }

--- a/src/main/java/io/rpg/model/actions/ShowDescriptionAction.java
+++ b/src/main/java/io/rpg/model/actions/ShowDescriptionAction.java
@@ -15,4 +15,9 @@ public class ShowDescriptionAction extends ConditionalAction {
     this.description = description;
     this.image = image;
   }
+
+  @Override
+  public void acceptActionEngine(ActionEngine engine) {
+    engine.onAction(this);
+  }
 }

--- a/src/main/java/io/rpg/model/actions/condition/ConditionEngine.java
+++ b/src/main/java/io/rpg/model/actions/condition/ConditionEngine.java
@@ -11,11 +11,16 @@ public final class ConditionEngine {
     this.weakRefController = new WeakReference<>(controller);
   }
 
+  private Controller controller() throws IllegalStateException {
+    Controller controller = weakRefController.get();
+    if (controller == null) throw new IllegalStateException("Controller was dropped but ConditionEngine still executes");
+    return controller;
+  }
+
   public boolean evaluate(ItemRequiredCondition condition) {
     // TODO: Implement this when the inventory gets implemented.
     // Scheme:
-//    return weakRefControler
-//        .get()
+//    return controller()
 //        .getPlayerController()
 //        .getPlayer()
 //        .getInventory()
@@ -25,8 +30,7 @@ public final class ConditionEngine {
   }
 
   public boolean evaluate(DefeatOpponentCondition condition) {
-    return weakRefController
-        .get()
+    return controller()
         .getPlayerController()
         .getPlayer()
         .getDefeatedOpponents()
@@ -36,8 +40,7 @@ public final class ConditionEngine {
   public boolean evaluate(LevelRequiredCondition condition) {
     // TODO: Implement this when the level system is implemented.
     // For now I just return true.
-//    return weakRefController
-//        .get()
+//    return controller()
 //        .getPlayerController()
 //        .getPlayer()
 //        .getLevel() >= condition.getLevel();


### PR DESCRIPTION
# Description

I did some refactoring in the controller as I did not like usage of the reflection in place where it is not required and the same effect can be achieved with much cleaner (IMO) code.

## What changed:

* Moved action logic to `ActionEngine`.
* Implemented visitor pattern (Actions accept the engine) with double dispatch.

Everything should word just as it did earlier.

Should be merged after #75

# Checklist

* [ ] Included code to test these changes
* [ ] Updated Jira
